### PR TITLE
update resemble dependency version to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "q": "1.0.1",
-    "resemble": "1.0.3",
+    "resemble": "1.2.1",
     "mkdirp": "0.5.0",
     "bluebird": "2.3.x",
     "simple-ioc-extra": "latest"


### PR DESCRIPTION
- updating resemble dependency version, so that it uses a newer version of canvas for its dependency, which will build correctly in the Docker container for components.