### PR TITLE
update resemble dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "q": "1.0.1",
-    "resemble": "1.2.1",
+    "resemble": "^1.4.0",
     "mkdirp": "0.5.0",
     "bluebird": "2.3.x",
     "simple-ioc-extra": "latest"


### PR DESCRIPTION
- updating the resemble dependency in order to make use of an updated version of canvas
- the outdated version of canvas is causing `npm install` to fail with Node v6.9.1 and npm v3.10.8