### PR TITLE
[GUI-1925][GUI-1923] substitute image-diff for resemble

### DIFF
--- a/lib/injector.js
+++ b/lib/injector.js
@@ -12,7 +12,8 @@
       "resemble": "resemble",
       "mkdirp": "mkdirp",
       "_": "underscore",
-      "path": "path"
+      "path": "path",
+      "imageDiff": "image-diff"
     });
     ioc.registerDirectories(__dirname, ["/runtime", "/util"]);
     return ioc;

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "test": "grunt"
   },
   "dependencies": {
-    "q": "1.0.1",
-    "resemble": "^1.4.0",
-    "mkdirp": "0.5.0",
     "bluebird": "2.3.x",
+    "image-diff": "^1.6.3",
+    "mkdirp": "0.5.0",
+    "q": "1.0.1",
     "simple-ioc-extra": "latest"
   },
   "devDependencies": {

--- a/src/injector.coffee
+++ b/src/injector.coffee
@@ -9,6 +9,7 @@ module.exports = ()->
     "mkdirp"    :"mkdirp"
     "_"         :"underscore"
     "path"      :"path"
+    "imageDiff" :"image-diff"
   }
 
   ioc.registerDirectories __dirname, [

--- a/src/runtime/ImageComparison.coffee
+++ b/src/runtime/ImageComparison.coffee
@@ -1,94 +1,76 @@
-domain = require('domain')
-
-module.exports = (options, path, Util, Promise, fsPromise, FileDef, _, resemble)->
+module.exports = (options, path, Util, Promise, FileDef, _, imageDiff) ->
 
   {baselineDirectory, sampleDirectory} = options
 
   class ImageComparison
 
-    THRESHOLD:0
+    THRESHOLD: 0
 
-    constructor:(@filename, @platform)->
+    constructor: (@filename, @platform) ->
       @name = @filename.replace(".png", "")
 
       @diffFilepath = path.join(options.reportDirectory, @platform, @name+"-diff.png")
       @diffUrl = path.join(@platform, @name+"-diff.png")
 
-    @compare:(filename, platform)->
+    @compare: (filename, platform) ->
       new ImageComparison(filename, platform).compare()
 
-    compare:()->
+    compare: () ->
       Util.promiseQueue [
         @copyFiles
         @runCompare
       ]
 
-    copyFiles:()=>
+    copyFiles: () =>
       Promise.props({
-        baselineFile:FileDef.makeCopy("baseline", @platform, @filename)
-        sampleFile:FileDef.makeCopy("sample", @platform, @filename)
-      }).then (results)=> _.extend(@, results)
+        baselineFile: FileDef.makeCopy("baseline", @platform, @filename)
+        sampleFile: FileDef.makeCopy("sample", @platform, @filename)
+      }).then (results) =>
+        _.extend(@, results)
 
-
-    runCompare:()=>
+    runCompare: () =>
       unless @baselineFile.exists and @sampleFile.exists
         @result = {
-          name:@name
-          failed:true
-          difference:0
+          name: @name
+          failed: true
+          difference: 0
           files:
-            base:@baselineFile
-            sample:@sampleFile
+            base: @baselineFile
+            sample: @sampleFile
             diff:
-              exists:false
+              exists: false
         }
         Promise.resolve(@result)
       else
         @runResemble()
 
-    resemblePromise:(image1, image2)-> new Promise (resolve, reject)=>
-      d = domain.create()
-      d.on "error", (e)->
-        resolve()
-      d.run ->
-        resemble
-          .resemble(image1)
-          .compareTo(image2)
-          .onComplete(resolve)
+    runResemble: () ->
+      new Promise (resolve, reject) =>
+        imageDiff.getFullResult {
+          actualImage: @sampleFile.filepath
+          expectedImage: @baselineFile.filepath
+          diffImage: @diffFilepath
+        }, (error, result) =>
+          reject(error) if error
+          resolve(@differenceResult(result)) unless error
 
+    differenceResult: (difference) =>
+      hasDifference = difference?.percentage > @THRESHOLD
+      @result = @getDifferenceObject(difference, hasDifference)
+      diffScreenshot = difference?.getImageDataUrl?()
+      Promise.resolve(@result)
 
-
-    runResemble:()->
-      @resemblePromise(@sampleFile.filepath, @baselineFile.filepath)
-        .then(@differenceResult)
-        .catch (e)->
-
-    storeScreenshot: (rawData)->
-      data = rawData.replace(/^data:image\/png;base64,/,"")
-      fsPromise.writeFileAsync(@diffFilepath, data, encoding:"base64")
-
-
-    differenceResult:(difference)=>
-      hasDifference = parseInt(difference.misMatchPercentage) > @THRESHOLD
-
-      @result = {
+    getDifferenceObject: (difference, hasDifference) =>
+      {
         @name
         failed: hasDifference
         difference
         files: {
-          sample:@sampleFile
-          base:@baselineFile
+          sample: @sampleFile
+          base: @baselineFile
           diff:
-            exists:true
-            filepath:@diffFilepath
-            url:@diffUrl
+            exists: true
+            filepath: @diffFilepath
+            url: @diffUrl
         }
       }
-
-      diffScreenshot = difference.getImageDataUrl()
-
-      if diffScreenshot
-        @storeScreenshot(diffScreenshot)
-          .then => @result
-      else
-        Promise.resolve(@result)


### PR DESCRIPTION
Requires ImageMagick and/or GraphicsMagick (uses gm, which can work with either; I am 95% sure I only have ImageMagick installed [via Homebrew]).